### PR TITLE
Fix renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,5 @@
   "suppressNotifications": [ "artifactErrors" ],
   "labels": [
     "dependency"
-  ],
-  "commodore-docker": {
-    "fileMatch": ["common.yml"]
-  }
+  ]
 }


### PR DESCRIPTION
We're confusing the default renovate bot with our manager. We should configure this on the runner side

fixes #2 


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
