### PR TITLE
Enable kube-state-metrics exporter

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -95,3 +95,5 @@ parameters:
                       resources:
                         requests:
                           storage: "20Gi"
+        kubeStateMetrics:
+          enabled: true

--- a/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_clusterRole.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_clusterRole.yaml
@@ -1,0 +1,113 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+  name: kubestatemetrics-monitoring
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - secrets
+      - nodes
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+      - ingresses
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - list
+      - watch

--- a/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_clusterRoleBinding.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_clusterRoleBinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+  name: kubestatemetrics-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubestatemetrics-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: kubestatemetrics-monitoring
+    namespace: syn-monitoring

--- a/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_deployment.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+  name: kubestatemetrics-monitoring
+  namespace: syn-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kubestatemetrics-monitoring
+      app.kubernetes.io/part-of: kube-prometheus
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: kube-state-metrics
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kubestatemetrics-monitoring
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 2.1.1
+    spec:
+      containers:
+        - args:
+            - --host=127.0.0.1
+            - --port=8081
+            - --telemetry-host=127.0.0.1
+            - --telemetry-port=8082
+          image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.1.1
+          name: kube-state-metrics
+          resources:
+            limits:
+              cpu: 100m
+              memory: 250Mi
+            requests:
+              cpu: 10m
+              memory: 190Mi
+        - args:
+            - --logtostderr
+            - --secure-listen-address=:8443
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - --upstream=http://127.0.0.1:8081/
+          image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          name: kube-rbac-proxy-main
+          ports:
+            - containerPort: 8443
+              name: https-main
+          resources:
+            limits:
+              cpu: 40m
+              memory: 40Mi
+            requests:
+              cpu: 20m
+              memory: 20Mi
+        - args:
+            - --logtostderr
+            - --secure-listen-address=:9443
+            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+            - --upstream=http://127.0.0.1:8082/
+          image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          name: kube-rbac-proxy-self
+          ports:
+            - containerPort: 9443
+              name: https-self
+          resources:
+            limits:
+              cpu: 20m
+              memory: 40Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kubestatemetrics-monitoring

--- a/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_prometheusRule.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_prometheusRule.yaml
@@ -1,0 +1,71 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+    prometheus: monitoring
+    role: alert-rules
+  name: kubestatemetrics-monitoring-rules
+  namespace: syn-monitoring
+spec:
+  groups:
+    - name: kube-state-metrics
+      rules:
+        - alert: KubeStateMetricsListErrors
+          annotations:
+            description: kube-state-metrics is experiencing errors at an elevated
+              rate in list operations. This is likely causing it to not be able to
+              expose metrics about Kubernetes objects correctly or at all.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kube-state-metrics/kubestatemetricslisterrors
+            summary: kube-state-metrics is experiencing errors in list operations.
+          expr: "(sum(rate(kube_state_metrics_list_total{job=\"kubestatemetrics-monitoring\"\
+            ,result=\"error\"}[5m]))\n  /\nsum(rate(kube_state_metrics_list_total{job=\"\
+            kubestatemetrics-monitoring\"}[5m])))\n> 0.01\n"
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStateMetricsWatchErrors
+          annotations:
+            description: kube-state-metrics is experiencing errors at an elevated
+              rate in watch operations. This is likely causing it to not be able to
+              expose metrics about Kubernetes objects correctly or at all.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kube-state-metrics/kubestatemetricswatcherrors
+            summary: kube-state-metrics is experiencing errors in watch operations.
+          expr: "(sum(rate(kube_state_metrics_watch_total{job=\"kubestatemetrics-monitoring\"\
+            ,result=\"error\"}[5m]))\n  /\nsum(rate(kube_state_metrics_watch_total{job=\"\
+            kubestatemetrics-monitoring\"}[5m])))\n> 0.01\n"
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStateMetricsShardingMismatch
+          annotations:
+            description: kube-state-metrics pods are running with different --total-shards
+              configuration, some Kubernetes objects may be exposed multiple times
+              or not exposed at all.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kube-state-metrics/kubestatemetricsshardingmismatch
+            summary: kube-state-metrics sharding is misconfigured.
+          expr: 'stdvar (kube_state_metrics_total_shards{job="kubestatemetrics-monitoring"})
+            != 0
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStateMetricsShardsMissing
+          annotations:
+            description: kube-state-metrics shards are missing, some Kubernetes objects
+              are not being exposed.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kube-state-metrics/kubestatemetricsshardsmissing
+            summary: kube-state-metrics shards are missing.
+          expr: "2^max(kube_state_metrics_total_shards{job=\"kubestatemetrics-monitoring\"\
+            }) - 1\n  -\nsum( 2 ^ max by (shard_ordinal) (kube_state_metrics_shard_ordinal{job=\"\
+            kubestatemetrics-monitoring\"}) )\n!= 0\n"
+          for: 15m
+          labels:
+            severity: critical

--- a/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_service.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_service.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+  name: kubestatemetrics-monitoring
+  namespace: syn-monitoring
+spec:
+  clusterIP: None
+  ports:
+    - name: https-main
+      port: 8443
+      targetPort: https-main
+    - name: https-self
+      port: 9443
+      targetPort: https-self
+  selector:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus

--- a/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_serviceAccount.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_serviceAccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+  name: kubestatemetrics-monitoring
+  namespace: syn-monitoring

--- a/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_serviceMonitor.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/90_monitoring_kubeStateMetrics_serviceMonitor.yaml
@@ -1,0 +1,38 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubestatemetrics-monitoring
+    app.kubernetes.io/part-of: kube-prometheus
+    app.kubernetes.io/version: 2.1.1
+  name: kubestatemetrics-monitoring
+  namespace: syn-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 30s
+      port: https-main
+      relabelings:
+        - action: labeldrop
+          regex: (pod|service|endpoint|namespace)
+      scheme: https
+      scrapeTimeout: 30s
+      tlsConfig:
+        insecureSkipVerify: true
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: https-self
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+  jobLabel: app.kubernetes.io/name
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kubestatemetrics-monitoring
+      app.kubernetes.io/part-of: kube-prometheus


### PR DESCRIPTION
This PR enables the kube-state-metrics exporter. This seems to "just work".

I also looked into deploying the exporter with multiple replicas, as that might be desirable if we use this package for billing as well. This is however not as straightforward, so if we want to do  that we should do so in a separate PR.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
