### PR TITLE
Enable control plane metrics

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -97,3 +97,5 @@ parameters:
                           storage: "20Gi"
         kubeStateMetrics:
           enabled: true
+        kubernetesControlPlane:
+          enabled: true

--- a/common.yml
+++ b/common.yml
@@ -32,7 +32,7 @@ parameters:
   components:
     prometheus:
       url: https://github.com/projectsyn/component-prometheus.git
-      version: ocp-specific-servicemonitors
+      version: v1.1.0
 
   prometheus:
     namespaces:

--- a/common.yml
+++ b/common.yml
@@ -32,7 +32,7 @@ parameters:
   components:
     prometheus:
       url: https://github.com/projectsyn/component-prometheus.git
-      version: v1.0.0
+      version: ocp-specific-servicemonitors
 
   prometheus:
     namespaces:

--- a/openshift4.yml
+++ b/openshift4.yml
@@ -6,5 +6,4 @@ parameters:
     prometheusOperator:
       installCRDs: false
     addons:
-      - remove-securitycontext
       - openshift4

--- a/openshift4.yml
+++ b/openshift4.yml
@@ -7,3 +7,4 @@ parameters:
       installCRDs: false
     addons:
       - remove-securitycontext
+      - openshift4

--- a/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_roleBindingSpecificNamespaces.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_roleBindingSpecificNamespaces.yaml
@@ -54,6 +54,60 @@ items:
       - kind: ServiceAccount
         name: prometheus-monitoring
         namespace: syn-monitoring
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 2.29.1
+      name: prometheus-monitoring
+      namespace: openshift-kube-scheduler
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: prometheus-monitoring
+    subjects:
+      - kind: ServiceAccount
+        name: prometheus-monitoring
+        namespace: syn-monitoring
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 2.29.1
+      name: prometheus-monitoring
+      namespace: openshift-kube-controller-manager
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: prometheus-monitoring
+    subjects:
+      - kind: ServiceAccount
+        name: prometheus-monitoring
+        namespace: syn-monitoring
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 2.29.1
+      name: prometheus-monitoring
+      namespace: openshift-dns
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: prometheus-monitoring
+    subjects:
+      - kind: ServiceAccount
+        name: prometheus-monitoring
+        namespace: syn-monitoring
 kind: RoleBindingList
 metadata:
   annotations:

--- a/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_roleSpecificNamespaces.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_roleSpecificNamespaces.yaml
@@ -111,6 +111,117 @@ items:
           - get
           - list
           - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 2.29.1
+      name: prometheus-monitoring
+      namespace: openshift-kube-scheduler
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - services
+          - endpoints
+          - pods
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 2.29.1
+      name: prometheus-monitoring
+      namespace: openshift-kube-controller-manager
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - services
+          - endpoints
+          - pods
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: prometheus
+        app.kubernetes.io/name: prometheus
+        app.kubernetes.io/part-of: kube-prometheus
+        app.kubernetes.io/version: 2.29.1
+      name: prometheus-monitoring
+      namespace: openshift-dns
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - services
+          - endpoints
+          - pods
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - extensions
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - networking.k8s.io
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
 kind: RoleList
 metadata:
   annotations:

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_prometheusRule.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_prometheusRule.yaml
@@ -1,0 +1,1247 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kube-prometheus
+    app.kubernetes.io/part-of: kube-prometheus
+    prometheus: monitoring
+    role: alert-rules
+  name: kubernetes-monitoring-rules
+  namespace: syn-monitoring
+spec:
+  groups:
+    - name: kubernetes-apps
+      rules:
+        - alert: KubePodCrashLooping
+          annotations:
+            description: 'Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+              }}) is in waiting state (reason: "CrashLoopBackOff").'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodcrashlooping
+            summary: Pod is crash looping.
+          expr: 'max_over_time(kube_pod_container_status_waiting_reason{reason="CrashLoopBackOff",
+            job="kube-state-metrics"}[5m]) >= 1
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubePodNotReady
+          annotations:
+            description: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in
+              a non-ready state for longer than 15 minutes.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepodnotready
+            summary: Pod has been in a non-ready state for more than 15 minutes.
+          expr: "sum by (namespace, pod) (\n  max by(namespace, pod) (\n    kube_pod_status_phase{job=\"\
+            kube-state-metrics\", phase=~\"Pending|Unknown\"}\n  ) * on(namespace,\
+            \ pod) group_left(owner_kind) topk by(namespace, pod) (\n    1, max by(namespace,\
+            \ pod, owner_kind) (kube_pod_owner{owner_kind!=\"Job\"})\n  )\n) > 0\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeDeploymentGenerationMismatch
+          annotations:
+            description: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but
+              has not been rolled back.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedeploymentgenerationmismatch
+            summary: Deployment generation mismatch due to possible roll-back
+          expr: "kube_deployment_status_observed_generation{job=\"kube-state-metrics\"\
+            }\n  !=\nkube_deployment_metadata_generation{job=\"kube-state-metrics\"\
+            }\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeDeploymentReplicasMismatch
+          annotations:
+            description: Deployment {{ $labels.namespace }}/{{ $labels.deployment
+              }} has not matched the expected number of replicas for longer than 15
+              minutes.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedeploymentreplicasmismatch
+            summary: Deployment has not matched the expected number of replicas.
+          expr: "(\n  kube_deployment_spec_replicas{job=\"kube-state-metrics\"}\n\
+            \    >\n  kube_deployment_status_replicas_available{job=\"kube-state-metrics\"\
+            }\n) and (\n  changes(kube_deployment_status_replicas_updated{job=\"kube-state-metrics\"\
+            }[10m])\n    ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeStatefulSetReplicasMismatch
+          annotations:
+            description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
+              }} has not matched the expected number of replicas for longer than 15
+              minutes.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubestatefulsetreplicasmismatch
+            summary: Deployment has not matched the expected number of replicas.
+          expr: "(\n  kube_statefulset_status_replicas_ready{job=\"kube-state-metrics\"\
+            }\n    !=\n  kube_statefulset_status_replicas{job=\"kube-state-metrics\"\
+            }\n) and (\n  changes(kube_statefulset_status_replicas_updated{job=\"\
+            kube-state-metrics\"}[10m])\n    ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeStatefulSetGenerationMismatch
+          annotations:
+            description: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
+              }} does not match, this indicates that the StatefulSet has failed but
+              has not been rolled back.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubestatefulsetgenerationmismatch
+            summary: StatefulSet generation mismatch due to possible roll-back
+          expr: "kube_statefulset_status_observed_generation{job=\"kube-state-metrics\"\
+            }\n  !=\nkube_statefulset_metadata_generation{job=\"kube-state-metrics\"\
+            }\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeStatefulSetUpdateNotRolledOut
+          annotations:
+            description: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset
+              }} update has not been rolled out.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubestatefulsetupdatenotrolledout
+            summary: StatefulSet update has not been rolled out.
+          expr: "(\n  max without (revision) (\n    kube_statefulset_status_current_revision{job=\"\
+            kube-state-metrics\"}\n      unless\n    kube_statefulset_status_update_revision{job=\"\
+            kube-state-metrics\"}\n  )\n    *\n  (\n    kube_statefulset_replicas{job=\"\
+            kube-state-metrics\"}\n      !=\n    kube_statefulset_status_replicas_updated{job=\"\
+            kube-state-metrics\"}\n  )\n)  and (\n  changes(kube_statefulset_status_replicas_updated{job=\"\
+            kube-state-metrics\"}[5m])\n    ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetRolloutStuck
+          annotations:
+            description: DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }}
+              has not finished or progressed for at least 15 minutes.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedaemonsetrolloutstuck
+            summary: DaemonSet rollout is stuck.
+          expr: "(\n  (\n    kube_daemonset_status_current_number_scheduled{job=\"\
+            kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
+            kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_misscheduled{job=\"\
+            kube-state-metrics\"}\n     !=\n    0\n  ) or (\n    kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
+            kube-state-metrics\"}\n  ) or (\n    kube_daemonset_status_number_available{job=\"\
+            kube-state-metrics\"}\n     !=\n    kube_daemonset_status_desired_number_scheduled{job=\"\
+            kube-state-metrics\"}\n  )\n) and (\n  changes(kube_daemonset_updated_number_scheduled{job=\"\
+            kube-state-metrics\"}[5m])\n    ==\n  0\n)\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeContainerWaiting
+          annotations:
+            description: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{
+              $labels.container}} has been in waiting state for longer than 1 hour.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontainerwaiting
+            summary: Pod container waiting longer than 1 hour
+          expr: 'sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics"})
+            > 0
+
+            '
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetNotScheduled
+          annotations:
+            description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
+              $labels.daemonset }} are not scheduled.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedaemonsetnotscheduled
+            summary: DaemonSet pods are not scheduled.
+          expr: "kube_daemonset_status_desired_number_scheduled{job=\"kube-state-metrics\"\
+            }\n  -\nkube_daemonset_status_current_number_scheduled{job=\"kube-state-metrics\"\
+            } > 0\n"
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetMisScheduled
+          annotations:
+            description: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{
+              $labels.daemonset }} are running where they are not supposed to run.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubedaemonsetmisscheduled
+            summary: DaemonSet pods are misscheduled.
+          expr: 'kube_daemonset_status_number_misscheduled{job="kube-state-metrics"}
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeJobCompletion
+          annotations:
+            description: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking
+              more than 12 hours to complete.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobcompletion
+            summary: Job did not complete in time
+          expr: 'kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}  >
+            0
+
+            '
+          for: 12h
+          labels:
+            severity: warning
+        - alert: KubeJobFailed
+          annotations:
+            description: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed
+              to complete. Removing failed job after investigation should clear this
+              alert.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubejobfailed
+            summary: Job failed to complete.
+          expr: 'kube_job_failed{job="kube-state-metrics"}  > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeHpaReplicasMismatch
+          annotations:
+            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
+              has not matched the desired number of replicas for longer than 15 minutes.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpareplicasmismatch
+            summary: HPA has not matched descired number of replicas.
+          expr: "(kube_horizontalpodautoscaler_status_desired_replicas{job=\"kube-state-metrics\"\
+            }\n  !=\nkube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
+            })\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
+            kube-state-metrics\"}\n  >\nkube_horizontalpodautoscaler_spec_min_replicas{job=\"\
+            kube-state-metrics\"})\n  and\n(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
+            kube-state-metrics\"}\n  <\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"\
+            kube-state-metrics\"})\n  and\nchanges(kube_horizontalpodautoscaler_status_current_replicas{job=\"\
+            kube-state-metrics\"}[15m]) == 0\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeHpaMaxedOut
+          annotations:
+            description: HPA {{ $labels.namespace }}/{{ $labels.horizontalpodautoscaler  }}
+              has been running at max replicas for longer than 15 minutes.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubehpamaxedout
+            summary: HPA is running at max replicas
+          expr: "kube_horizontalpodautoscaler_status_current_replicas{job=\"kube-state-metrics\"\
+            }\n  ==\nkube_horizontalpodautoscaler_spec_max_replicas{job=\"kube-state-metrics\"\
+            }\n"
+          for: 15m
+          labels:
+            severity: warning
+    - name: kubernetes-resources
+      rules:
+        - alert: KubeCPUOvercommit
+          annotations:
+            description: Cluster has overcommitted CPU resource requests for Pods
+              by {{ $value }} CPU shares and cannot tolerate node failure.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecpuovercommit
+            summary: Cluster has overcommitted CPU resource requests.
+          expr: 'sum(namespace_cpu:kube_pod_container_resource_requests:sum{}) - (sum(kube_node_status_allocatable{resource="cpu"})
+            - max(kube_node_status_allocatable{resource="cpu"})) > 0
+
+            and
+
+            (sum(kube_node_status_allocatable{resource="cpu"}) - max(kube_node_status_allocatable{resource="cpu"}))
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeMemoryOvercommit
+          annotations:
+            description: Cluster has overcommitted memory resource requests for Pods
+              by {{ $value }} bytes and cannot tolerate node failure.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubememoryovercommit
+            summary: Cluster has overcommitted memory resource requests.
+          expr: 'sum(namespace_memory:kube_pod_container_resource_requests:sum{})
+            - (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"}))
+            > 0
+
+            and
+
+            (sum(kube_node_status_allocatable{resource="memory"}) - max(kube_node_status_allocatable{resource="memory"}))
+            > 0
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeCPUQuotaOvercommit
+          annotations:
+            description: Cluster has overcommitted CPU resource requests for Namespaces.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecpuquotaovercommit
+            summary: Cluster has overcommitted CPU resource requests.
+          expr: "sum(kube_resourcequota{job=\"kube-state-metrics\", type=\"hard\"\
+            , resource=\"cpu\"})\n  /\nsum(kube_node_status_allocatable{resource=\"\
+            cpu\"})\n  > 1.5\n"
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeMemoryQuotaOvercommit
+          annotations:
+            description: Cluster has overcommitted memory resource requests for Namespaces.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubememoryquotaovercommit
+            summary: Cluster has overcommitted memory resource requests.
+          expr: "sum(kube_resourcequota{job=\"kube-state-metrics\", type=\"hard\"\
+            , resource=\"memory\"})\n  /\nsum(kube_node_status_allocatable{resource=\"\
+            memory\",job=\"kube-state-metrics\"})\n  > 1.5\n"
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeQuotaAlmostFull
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaalmostfull
+            summary: Namespace quota is going to be full.
+          expr: "kube_resourcequota{job=\"kube-state-metrics\", type=\"used\"}\n \
+            \ / ignoring(instance, job, type)\n(kube_resourcequota{job=\"kube-state-metrics\"\
+            , type=\"hard\"} > 0)\n  > 0.9 < 1\n"
+          for: 15m
+          labels:
+            severity: info
+        - alert: KubeQuotaFullyUsed
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotafullyused
+            summary: Namespace quota is fully used.
+          expr: "kube_resourcequota{job=\"kube-state-metrics\", type=\"used\"}\n \
+            \ / ignoring(instance, job, type)\n(kube_resourcequota{job=\"kube-state-metrics\"\
+            , type=\"hard\"} > 0)\n  == 1\n"
+          for: 15m
+          labels:
+            severity: info
+        - alert: KubeQuotaExceeded
+          annotations:
+            description: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubequotaexceeded
+            summary: Namespace quota has exceeded the limits.
+          expr: "kube_resourcequota{job=\"kube-state-metrics\", type=\"used\"}\n \
+            \ / ignoring(instance, job, type)\n(kube_resourcequota{job=\"kube-state-metrics\"\
+            , type=\"hard\"} > 0)\n  > 1\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: CPUThrottlingHigh
+          annotations:
+            description: '{{ $value | humanizePercentage }} throttling of CPU in namespace
+              {{ $labels.namespace }} for container {{ $labels.container }} in pod
+              {{ $labels.pod }}.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/cputhrottlinghigh
+            summary: Processes experience elevated CPU throttling.
+          expr: "sum(increase(container_cpu_cfs_throttled_periods_total{container!=\"\
+            \", }[5m])) by (container, pod, namespace)\n  /\nsum(increase(container_cpu_cfs_periods_total{}[5m]))\
+            \ by (container, pod, namespace)\n  > ( 25 / 100 )\n"
+          for: 15m
+          labels:
+            severity: info
+    - name: kubernetes-storage
+      rules:
+        - alert: KubePersistentVolumeFillingUp
+          annotations:
+            description: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+              }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage
+              }} free.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+            summary: PersistentVolume is filling up.
+          expr: "(\n  kubelet_volume_stats_available_bytes{job=\"kubelet\", metrics_path=\"\
+            /metrics\"}\n    /\n  kubelet_volume_stats_capacity_bytes{job=\"kubelet\"\
+            , metrics_path=\"/metrics\"}\n) < 0.03\nand\nkubelet_volume_stats_used_bytes{job=\"\
+            kubelet\", metrics_path=\"/metrics\"} > 0\n"
+          for: 1m
+          labels:
+            severity: critical
+        - alert: KubePersistentVolumeFillingUp
+          annotations:
+            description: Based on recent sampling, the PersistentVolume claimed by
+              {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace
+              }} is expected to fill up within four days. Currently {{ $value | humanizePercentage
+              }} is available.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumefillingup
+            summary: PersistentVolume is filling up.
+          expr: "(\n  kubelet_volume_stats_available_bytes{job=\"kubelet\", metrics_path=\"\
+            /metrics\"}\n    /\n  kubelet_volume_stats_capacity_bytes{job=\"kubelet\"\
+            , metrics_path=\"/metrics\"}\n) < 0.15\nand\nkubelet_volume_stats_used_bytes{job=\"\
+            kubelet\", metrics_path=\"/metrics\"} > 0\nand\npredict_linear(kubelet_volume_stats_available_bytes{job=\"\
+            kubelet\", metrics_path=\"/metrics\"}[6h], 4 * 24 * 3600) < 0\n"
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubePersistentVolumeErrors
+          annotations:
+            description: The persistent volume {{ $labels.persistentvolume }} has
+              status {{ $labels.phase }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubepersistentvolumeerrors
+            summary: PersistentVolume is having issues with provisioning.
+          expr: 'kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"}
+            > 0
+
+            '
+          for: 5m
+          labels:
+            severity: critical
+    - name: kubernetes-system
+      rules:
+        - alert: KubeVersionMismatch
+          annotations:
+            description: There are {{ $value }} different semantic versions of Kubernetes
+              components running.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeversionmismatch
+            summary: Different semantic versions of Kubernetes components running.
+          expr: 'count(count by (git_version) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"git_version","$1","git_version","(v[0-9]*.[0-9]*).*")))
+            > 1
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeClientErrors
+          annotations:
+            description: Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance
+              }}' is experiencing {{ $value | humanizePercentage }} errors.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclienterrors
+            summary: Kubernetes API server client is experiencing errors.
+          expr: "(sum(rate(rest_client_requests_total{code=~\"5..\"}[5m])) by (instance,\
+            \ job, namespace)\n  /\nsum(rate(rest_client_requests_total[5m])) by (instance,\
+            \ job, namespace))\n> 0.01\n"
+          for: 15m
+          labels:
+            severity: warning
+    - name: kube-apiserver-slos
+      rules:
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+          expr: 'sum(apiserver_request:burnrate1h) > (14.40 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate5m) > (14.40 * 0.01000)
+
+            '
+          for: 2m
+          labels:
+            long: 1h
+            severity: critical
+            short: 5m
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+          expr: 'sum(apiserver_request:burnrate6h) > (6.00 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate30m) > (6.00 * 0.01000)
+
+            '
+          for: 15m
+          labels:
+            long: 6h
+            severity: critical
+            short: 30m
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+          expr: 'sum(apiserver_request:burnrate1d) > (3.00 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate2h) > (3.00 * 0.01000)
+
+            '
+          for: 1h
+          labels:
+            long: 1d
+            severity: warning
+            short: 2h
+        - alert: KubeAPIErrorBudgetBurn
+          annotations:
+            description: The API server is burning too much error budget.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapierrorbudgetburn
+            summary: The API server is burning too much error budget.
+          expr: 'sum(apiserver_request:burnrate3d) > (1.00 * 0.01000)
+
+            and
+
+            sum(apiserver_request:burnrate6h) > (1.00 * 0.01000)
+
+            '
+          for: 3h
+          labels:
+            long: 3d
+            severity: warning
+            short: 6h
+    - name: kubernetes-system-apiserver
+      rules:
+        - alert: KubeClientCertificateExpiration
+          annotations:
+            description: A client certificate used to authenticate to the apiserver
+              is expiring in less than 7.0 days.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclientcertificateexpiration
+            summary: Client certificate is about to expire.
+          expr: 'apiserver_client_certificate_expiration_seconds_count{job="apiserver"}
+            > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m])))
+            < 604800
+
+            '
+          labels:
+            severity: warning
+        - alert: KubeClientCertificateExpiration
+          annotations:
+            description: A client certificate used to authenticate to the apiserver
+              is expiring in less than 24.0 hours.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeclientcertificateexpiration
+            summary: Client certificate is about to expire.
+          expr: 'apiserver_client_certificate_expiration_seconds_count{job="apiserver"}
+            > 0 and on(job) histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="apiserver"}[5m])))
+            < 86400
+
+            '
+          labels:
+            severity: critical
+        - alert: AggregatedAPIErrors
+          annotations:
+            description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
+              }} has reported errors. It has appeared unavailable {{ $value | humanize
+              }} times averaged over the past 10m.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/aggregatedapierrors
+            summary: An aggregated API has reported errors.
+          expr: 'sum by(name, namespace)(increase(aggregator_unavailable_apiservice_total[10m]))
+            > 4
+
+            '
+          labels:
+            severity: warning
+        - alert: AggregatedAPIDown
+          annotations:
+            description: An aggregated API {{ $labels.name }}/{{ $labels.namespace
+              }} has been only {{ $value | humanize }}% available over the last 10m.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/aggregatedapidown
+            summary: An aggregated API is down.
+          expr: '(1 - max by(name, namespace)(avg_over_time(aggregator_unavailable_apiservice[10m])))
+            * 100 < 85
+
+            '
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeAPIDown
+          annotations:
+            description: KubeAPI has disappeared from Prometheus target discovery.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapidown
+            summary: Target disappeared from Prometheus target discovery.
+          expr: 'absent(up{job="apiserver"} == 1)
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeAPITerminatedRequests
+          annotations:
+            description: The apiserver has terminated {{ $value | humanizePercentage
+              }} of its incoming requests.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeapiterminatedrequests
+            summary: The apiserver has terminated {{ $value | humanizePercentage }}
+              of its incoming requests.
+          expr: 'sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))  /
+            (  sum(rate(apiserver_request_total{job="apiserver"}[10m])) + sum(rate(apiserver_request_terminations_total{job="apiserver"}[10m]))
+            ) > 0.20
+
+            '
+          for: 5m
+          labels:
+            severity: warning
+    - name: kubernetes-system-kubelet
+      rules:
+        - alert: KubeNodeNotReady
+          annotations:
+            description: '{{ $labels.node }} has been unready for more than 15 minutes.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodenotready
+            summary: Node is not ready.
+          expr: 'kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"}
+            == 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeNodeUnreachable
+          annotations:
+            description: '{{ $labels.node }} is unreachable and some workloads may
+              be rescheduled.'
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodeunreachable
+            summary: Node is unreachable.
+          expr: '(kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"}
+            unless ignoring(key,value) kube_node_spec_taint{job="kube-state-metrics",key=~"ToBeDeletedByClusterAutoscaler|cloud.google.com/impending-node-termination|aws-node-termination-handler/spot-itn"})
+            == 1
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletTooManyPods
+          annotations:
+            description: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
+              }} of its Pod capacity.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubelettoomanypods
+            summary: Kubelet is running at capacity.
+          expr: "count by(node) (\n  (kube_pod_status_phase{job=\"kube-state-metrics\"\
+            ,phase=\"Running\"} == 1) * on(instance,pod,namespace,cluster) group_left(node)\
+            \ topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job=\"kube-state-metrics\"\
+            })\n)\n/\nmax by(node) (\n  kube_node_status_capacity{job=\"kube-state-metrics\"\
+            ,resource=\"pods\"} != 1\n) > 0.95\n"
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeNodeReadinessFlapping
+          annotations:
+            description: The readiness status of node {{ $labels.node }} has changed
+              {{ $value }} times in the last 15 minutes.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubenodereadinessflapping
+            summary: Node readiness status is flapping.
+          expr: 'sum(changes(kube_node_status_condition{status="true",condition="Ready"}[15m]))
+            by (node) > 2
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletPlegDurationHigh
+          annotations:
+            description: The Kubelet Pod Lifecycle Event Generator has a 99th percentile
+              duration of {{ $value }} seconds on node {{ $labels.node }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletplegdurationhigh
+            summary: Kubelet Pod Lifecycle Event Generator is taking too long to relist.
+          expr: 'node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile{quantile="0.99"}
+            >= 10
+
+            '
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeletPodStartUpLatencyHigh
+          annotations:
+            description: Kubelet Pod startup 99th percentile latency is {{ $value
+              }} seconds on node {{ $labels.node }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletpodstartuplatencyhigh
+            summary: Kubelet Pod startup latency is too high.
+          expr: 'histogram_quantile(0.99, sum(rate(kubelet_pod_worker_duration_seconds_bucket{job="kubelet",
+            metrics_path="/metrics"}[5m])) by (instance, le)) * on(instance) group_left(node)
+            kubelet_node_name{job="kubelet", metrics_path="/metrics"} > 60
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletClientCertificateExpiration
+          annotations:
+            description: Client certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletclientcertificateexpiration
+            summary: Kubelet client certificate is about to expire.
+          expr: 'kubelet_certificate_manager_client_ttl_seconds < 604800
+
+            '
+          labels:
+            severity: warning
+        - alert: KubeletClientCertificateExpiration
+          annotations:
+            description: Client certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletclientcertificateexpiration
+            summary: Kubelet client certificate is about to expire.
+          expr: 'kubelet_certificate_manager_client_ttl_seconds < 86400
+
+            '
+          labels:
+            severity: critical
+        - alert: KubeletServerCertificateExpiration
+          annotations:
+            description: Server certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletservercertificateexpiration
+            summary: Kubelet server certificate is about to expire.
+          expr: 'kubelet_certificate_manager_server_ttl_seconds < 604800
+
+            '
+          labels:
+            severity: warning
+        - alert: KubeletServerCertificateExpiration
+          annotations:
+            description: Server certificate for Kubelet on node {{ $labels.node }}
+              expires in {{ $value | humanizeDuration }}.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletservercertificateexpiration
+            summary: Kubelet server certificate is about to expire.
+          expr: 'kubelet_certificate_manager_server_ttl_seconds < 86400
+
+            '
+          labels:
+            severity: critical
+        - alert: KubeletClientCertificateRenewalErrors
+          annotations:
+            description: Kubelet on node {{ $labels.node }} has failed to renew its
+              client certificate ({{ $value | humanize }} errors in the last 5 minutes).
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletclientcertificaterenewalerrors
+            summary: Kubelet has failed to renew its client certificate.
+          expr: 'increase(kubelet_certificate_manager_client_expiration_renew_errors[5m])
+            > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletServerCertificateRenewalErrors
+          annotations:
+            description: Kubelet on node {{ $labels.node }} has failed to renew its
+              server certificate ({{ $value | humanize }} errors in the last 5 minutes).
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletservercertificaterenewalerrors
+            summary: Kubelet has failed to renew its server certificate.
+          expr: 'increase(kubelet_server_expiration_renew_errors[5m]) > 0
+
+            '
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletDown
+          annotations:
+            description: Kubelet has disappeared from Prometheus target discovery.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeletdown
+            summary: Target disappeared from Prometheus target discovery.
+          expr: 'absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+    - name: kubernetes-system-scheduler
+      rules:
+        - alert: KubeSchedulerDown
+          annotations:
+            description: KubeScheduler has disappeared from Prometheus target discovery.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubeschedulerdown
+            summary: Target disappeared from Prometheus target discovery.
+          expr: 'absent(up{job="kube-scheduler"} == 1)
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+    - name: kubernetes-system-controller-manager
+      rules:
+        - alert: KubeControllerManagerDown
+          annotations:
+            description: KubeControllerManager has disappeared from Prometheus target
+              discovery.
+            runbook_url: https://runbooks.prometheus-operator.dev/runbooks/kubernetes/kubecontrollermanagerdown
+            summary: Target disappeared from Prometheus target discovery.
+          expr: 'absent(up{job="kube-controller-manager"} == 1)
+
+            '
+          for: 15m
+          labels:
+            severity: critical
+    - name: kube-apiserver-burnrate.rules
+      rules:
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[1d]))\n    -\n    (\n      (\n       \
+            \ sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[1d]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[1d]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[1d]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"LIST|GET\",code=~\"5..\"}[1d]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[1d]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate1d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[1h]))\n    -\n    (\n      (\n       \
+            \ sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[1h]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[1h]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[1h]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"LIST|GET\",code=~\"5..\"}[1h]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[1h]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate1h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[2h]))\n    -\n    (\n      (\n       \
+            \ sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[2h]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[2h]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[2h]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"LIST|GET\",code=~\"5..\"}[2h]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[2h]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate2h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[30m]))\n    -\n    (\n      (\n      \
+            \  sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[30m]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[30m]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[30m]))\n    )\n  )\n\
+            \  +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"LIST|GET\",code=~\"5..\"}[30m]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[30m]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate30m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[3d]))\n    -\n    (\n      (\n       \
+            \ sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[3d]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[3d]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[3d]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"LIST|GET\",code=~\"5..\"}[3d]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[3d]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate3d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[5m]))\n    -\n    (\n      (\n       \
+            \ sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[5m]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[5m]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[5m]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"LIST|GET\",code=~\"5..\"}[5m]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[5m]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate5m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[6h]))\n    -\n    (\n      (\n       \
+            \ sum by (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[6h]))\n\
+            \        or\n        vector(0)\n      )\n      +\n      sum by (cluster)\
+            \ (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\",verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[6h]))\n      +\n      sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[6h]))\n    )\n  )\n \
+            \ +\n  # errors\n  sum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"LIST|GET\",code=~\"5..\"}[6h]))\n)\n/\nsum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"LIST|GET\"}[6h]))\n"
+          labels:
+            verb: read
+          record: apiserver_request:burnrate6h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[1d]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[1d]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1d]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate1d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[1h]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[1h]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[1h]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate1h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[2h]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[2h]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[2h]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate2h
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[30m]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[30m]))\n  )\n  +\n  sum by\
+            \ (cluster) (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[30m]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[30m]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate30m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[3d]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[3d]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[3d]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate3d
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[5m]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[5m]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[5m]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate5m
+        - expr: "(\n  (\n    # too slow\n    sum by (cluster) (rate(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h]))\n    -\n    sum by\
+            \ (cluster) (rate(apiserver_request_duration_seconds_bucket{job=\"apiserver\"\
+            ,verb=~\"POST|PUT|PATCH|DELETE\",le=\"1\"}[6h]))\n  )\n  +\n  sum by (cluster)\
+            \ (rate(apiserver_request_total{job=\"apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"\
+            ,code=~\"5..\"}[6h]))\n)\n/\nsum by (cluster) (rate(apiserver_request_total{job=\"\
+            apiserver\",verb=~\"POST|PUT|PATCH|DELETE\"}[6h]))\n"
+          labels:
+            verb: write
+          record: apiserver_request:burnrate6h
+    - name: kube-apiserver-histogram.rules
+      rules:
+        - expr: 'histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"LIST|GET"}[5m])))
+            > 0
+
+            '
+          labels:
+            quantile: '0.99'
+            verb: read
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum by (cluster, le, resource) (rate(apiserver_request_duration_seconds_bucket{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m])))
+            > 0
+
+            '
+          labels:
+            quantile: '0.99'
+            verb: write
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(apiserver_request_duration_seconds_bucket{job="apiserver",subresource!="log",verb!~"LIST|WATCH|WATCHLIST|DELETECOLLECTION|PROXY|CONNECT"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:apiserver_request_duration_seconds:histogram_quantile
+    - interval: 3m
+      name: kube-apiserver-availability.rules
+      rules:
+        - expr: 'avg_over_time(code_verb:apiserver_request_total:increase1h[30d])
+            * 24 * 30
+
+            '
+          record: code_verb:apiserver_request_total:increase30d
+        - expr: 'sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"LIST|GET"})
+
+            '
+          labels:
+            verb: read
+          record: code:apiserver_request_total:increase30d
+        - expr: 'sum by (cluster, code) (code_verb:apiserver_request_total:increase30d{verb=~"POST|PUT|PATCH|DELETE"})
+
+            '
+          labels:
+            verb: write
+          record: code:apiserver_request_total:increase30d
+        - expr: "1 - (\n  (\n    # write too slow\n    sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~\"\
+            POST|PUT|PATCH|DELETE\"}[30d]))\n    -\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            POST|PUT|PATCH|DELETE\",le=\"1\"}[30d]))\n  ) +\n  (\n    # read too slow\n\
+            \    sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~\"\
+            LIST|GET\"}[30d]))\n    -\n    (\n      (\n        sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            LIST|GET\",scope=~\"resource|\",le=\"1\"}[30d]))\n        or\n       \
+            \ vector(0)\n      )\n      +\n      sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            LIST|GET\",scope=\"namespace\",le=\"5\"}[30d]))\n      +\n      sum by\
+            \ (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            LIST|GET\",scope=\"cluster\",le=\"40\"}[30d]))\n    )\n  ) +\n  # errors\n\
+            \  sum by (cluster) (code:apiserver_request_total:increase30d{code=~\"\
+            5..\"} or vector(0))\n)\n/\nsum by (cluster) (code:apiserver_request_total:increase30d)\n"
+          labels:
+            verb: all
+          record: apiserver_request:availability30d
+        - expr: "1 - (\n  sum by (cluster) (increase(apiserver_request_duration_seconds_count{job=\"\
+            apiserver\",verb=~\"LIST|GET\"}[30d]))\n  -\n  (\n    # too slow\n   \
+            \ (\n      sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=~\"resource|\",le=\"1\"}[30d]))\n\
+            \      or\n      vector(0)\n    )\n    +\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=\"namespace\",le=\"5\"}[30d]))\n\
+            \    +\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{job=\"\
+            apiserver\",verb=~\"LIST|GET\",scope=\"cluster\",le=\"40\"}[30d]))\n \
+            \ )\n  +\n  # errors\n  sum by (cluster) (code:apiserver_request_total:increase30d{verb=\"\
+            read\",code=~\"5..\"} or vector(0))\n)\n/\nsum by (cluster) (code:apiserver_request_total:increase30d{verb=\"\
+            read\"})\n"
+          labels:
+            verb: read
+          record: apiserver_request:availability30d
+        - expr: "1 - (\n  (\n    # too slow\n    sum by (cluster) (increase(apiserver_request_duration_seconds_count{verb=~\"\
+            POST|PUT|PATCH|DELETE\"}[30d]))\n    -\n    sum by (cluster) (increase(apiserver_request_duration_seconds_bucket{verb=~\"\
+            POST|PUT|PATCH|DELETE\",le=\"1\"}[30d]))\n  )\n  +\n  # errors\n  sum\
+            \ by (cluster) (code:apiserver_request_total:increase30d{verb=\"write\"\
+            ,code=~\"5..\"} or vector(0))\n)\n/\nsum by (cluster) (code:apiserver_request_total:increase30d{verb=\"\
+            write\"})\n"
+          labels:
+            verb: write
+          record: apiserver_request:availability30d
+        - expr: 'sum by (cluster,code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"LIST|GET"}[5m]))
+
+            '
+          labels:
+            verb: read
+          record: code_resource:apiserver_request_total:rate5m
+        - expr: 'sum by (cluster,code,resource) (rate(apiserver_request_total{job="apiserver",verb=~"POST|PUT|PATCH|DELETE"}[5m]))
+
+            '
+          labels:
+            verb: write
+          record: code_resource:apiserver_request_total:rate5m
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"2.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"3.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"4.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+        - expr: 'sum by (cluster, code, verb) (increase(apiserver_request_total{job="apiserver",verb=~"LIST|GET|POST|PUT|PATCH|DELETE",code=~"5.."}[1h]))
+
+            '
+          record: code_verb:apiserver_request_total:increase1h
+    - name: k8s.rules
+      rules:
+        - expr: "sum by (cluster, namespace, pod, container) (\n  irate(container_cpu_usage_seconds_total{job=\"\
+            kubelet\", metrics_path=\"/metrics/cadvisor\", image!=\"\"}[5m])\n) *\
+            \ on (cluster, namespace, pod) group_left(node) topk by (cluster, namespace,\
+            \ pod) (\n  1, max by(cluster, namespace, pod, node) (kube_pod_info{node!=\"\
+            \"})\n)\n"
+          record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
+        - expr: "container_memory_working_set_bytes{job=\"kubelet\", metrics_path=\"\
+            /metrics/cadvisor\", image!=\"\"}\n* on (namespace, pod) group_left(node)\
+            \ topk by(namespace, pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\
+            \"})\n)\n"
+          record: node_namespace_pod_container:container_memory_working_set_bytes
+        - expr: "container_memory_rss{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"\
+            , image!=\"\"}\n* on (namespace, pod) group_left(node) topk by(namespace,\
+            \ pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\"})\n\
+            )\n"
+          record: node_namespace_pod_container:container_memory_rss
+        - expr: "container_memory_cache{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"\
+            , image!=\"\"}\n* on (namespace, pod) group_left(node) topk by(namespace,\
+            \ pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\"})\n\
+            )\n"
+          record: node_namespace_pod_container:container_memory_cache
+        - expr: "container_memory_swap{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"\
+            , image!=\"\"}\n* on (namespace, pod) group_left(node) topk by(namespace,\
+            \ pod) (1,\n  max by(namespace, pod, node) (kube_pod_info{node!=\"\"})\n\
+            )\n"
+          record: node_namespace_pod_container:container_memory_swap
+        - expr: "kube_pod_container_resource_requests{resource=\"memory\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n  (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n)\n"
+          record: cluster:namespace:pod_memory:active:kube_pod_container_resource_requests
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_requests{resource=\"memory\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_memory:kube_pod_container_resource_requests:sum
+        - expr: "kube_pod_container_resource_requests{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n  (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n)\n"
+          record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_requests{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_cpu:kube_pod_container_resource_requests:sum
+        - expr: "kube_pod_container_resource_limits{resource=\"memory\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n  (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n)\n"
+          record: cluster:namespace:pod_memory:active:kube_pod_container_resource_limits
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_limits{resource=\"memory\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_memory:kube_pod_container_resource_limits:sum
+        - expr: "kube_pod_container_resource_limits{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }  * on (namespace, pod, cluster)\ngroup_left() max by (namespace, pod)\
+            \ (\n (kube_pod_status_phase{phase=~\"Pending|Running\"} == 1)\n )\n"
+          record: cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits
+        - expr: "sum by (namespace, cluster) (\n    sum by (namespace, pod, cluster)\
+            \ (\n        max by (namespace, pod, container, cluster) (\n         \
+            \ kube_pod_container_resource_limits{resource=\"cpu\",job=\"kube-state-metrics\"\
+            }\n        ) * on(namespace, pod, cluster) group_left() max by (namespace,\
+            \ pod, cluster) (\n          kube_pod_status_phase{phase=~\"Pending|Running\"\
+            } == 1\n        )\n    )\n)\n"
+          record: namespace_cpu:kube_pod_container_resource_limits:sum
+        - expr: "max by (cluster, namespace, workload, pod) (\n  label_replace(\n\
+            \    label_replace(\n      kube_pod_owner{job=\"kube-state-metrics\",\
+            \ owner_kind=\"ReplicaSet\"},\n      \"replicaset\", \"$1\", \"owner_name\"\
+            , \"(.*)\"\n    ) * on(replicaset, namespace) group_left(owner_name) topk\
+            \ by(replicaset, namespace) (\n      1, max by (replicaset, namespace,\
+            \ owner_name) (\n        kube_replicaset_owner{job=\"kube-state-metrics\"\
+            }\n      )\n    ),\n    \"workload\", \"$1\", \"owner_name\", \"(.*)\"\
+            \n  )\n)\n"
+          labels:
+            workload_type: deployment
+          record: namespace_workload_pod:kube_pod_owner:relabel
+        - expr: "max by (cluster, namespace, workload, pod) (\n  label_replace(\n\
+            \    kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"DaemonSet\"\
+            },\n    \"workload\", \"$1\", \"owner_name\", \"(.*)\"\n  )\n)\n"
+          labels:
+            workload_type: daemonset
+          record: namespace_workload_pod:kube_pod_owner:relabel
+        - expr: "max by (cluster, namespace, workload, pod) (\n  label_replace(\n\
+            \    kube_pod_owner{job=\"kube-state-metrics\", owner_kind=\"StatefulSet\"\
+            },\n    \"workload\", \"$1\", \"owner_name\", \"(.*)\"\n  )\n)\n"
+          labels:
+            workload_type: statefulset
+          record: namespace_workload_pod:kube_pod_owner:relabel
+    - name: kube-scheduler.rules
+      rules:
+        - expr: 'histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.99'
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.9'
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m]))
+            without(instance, pod))
+
+            '
+          labels:
+            quantile: '0.5'
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+    - name: node.rules
+      rules:
+        - expr: "topk by(namespace, pod) (1,\n  max by (node, namespace, pod) (\n\
+            \    label_replace(kube_pod_info{job=\"kube-state-metrics\",node!=\"\"\
+            }, \"pod\", \"$1\", \"pod\", \"(.*)\")\n))\n"
+          record: 'node_namespace_pod:kube_pod_info:'
+        - expr: "count by (cluster, node) (sum by (node, cpu) (\n  node_cpu_seconds_total{job=\"\
+            node-exporter\"}\n* on (namespace, pod) group_left(node)\n  topk by(namespace,\
+            \ pod) (1, node_namespace_pod:kube_pod_info:)\n))\n"
+          record: node:node_num_cpu:sum
+        - expr: "sum(\n  node_memory_MemAvailable_bytes{job=\"node-exporter\"} or\n\
+            \  (\n    node_memory_Buffers_bytes{job=\"node-exporter\"} +\n    node_memory_Cached_bytes{job=\"\
+            node-exporter\"} +\n    node_memory_MemFree_bytes{job=\"node-exporter\"\
+            } +\n    node_memory_Slab_bytes{job=\"node-exporter\"}\n  )\n) by (cluster)\n"
+          record: :node_memory_MemAvailable_bytes:sum
+    - name: kubelet.rules
+      rules:
+        - expr: 'histogram_quantile(0.99, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m]))
+            by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="kubelet",
+            metrics_path="/metrics"})
+
+            '
+          labels:
+            quantile: '0.99'
+          record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.9, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m]))
+            by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="kubelet",
+            metrics_path="/metrics"})
+
+            '
+          labels:
+            quantile: '0.9'
+          record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile
+        - expr: 'histogram_quantile(0.5, sum(rate(kubelet_pleg_relist_duration_seconds_bucket[5m]))
+            by (instance, le) * on(instance) group_left(node) kubelet_node_name{job="kubelet",
+            metrics_path="/metrics"})
+
+            '
+          labels:
+            quantile: '0.5'
+          record: node_quantile:kubelet_pleg_relist_duration_seconds:histogram_quantile

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorApiserver.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorApiserver.yaml
@@ -1,0 +1,78 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: apiserver
+    app.kubernetes.io/part-of: syn
+  name: kube-apiserver
+  namespace: syn-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: kubelet_docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|object_counts|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: transformation_(transformation_latencies_microseconds|failures_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (admission_quota_controller_adds|admission_quota_controller_depth|admission_quota_controller_longest_running_processor_microseconds|admission_quota_controller_queue_latency|admission_quota_controller_unfinished_work_seconds|admission_quota_controller_work_duration|APIServiceOpenAPIAggregationControllerQueue1_adds|APIServiceOpenAPIAggregationControllerQueue1_depth|APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds|APIServiceOpenAPIAggregationControllerQueue1_queue_latency|APIServiceOpenAPIAggregationControllerQueue1_retries|APIServiceOpenAPIAggregationControllerQueue1_unfinished_work_seconds|APIServiceOpenAPIAggregationControllerQueue1_work_duration|APIServiceRegistrationController_adds|APIServiceRegistrationController_depth|APIServiceRegistrationController_longest_running_processor_microseconds|APIServiceRegistrationController_queue_latency|APIServiceRegistrationController_retries|APIServiceRegistrationController_unfinished_work_seconds|APIServiceRegistrationController_work_duration|autoregister_adds|autoregister_depth|autoregister_longest_running_processor_microseconds|autoregister_queue_latency|autoregister_retries|autoregister_unfinished_work_seconds|autoregister_work_duration|AvailableConditionController_adds|AvailableConditionController_depth|AvailableConditionController_longest_running_processor_microseconds|AvailableConditionController_queue_latency|AvailableConditionController_retries|AvailableConditionController_unfinished_work_seconds|AvailableConditionController_work_duration|crd_autoregistration_controller_adds|crd_autoregistration_controller_depth|crd_autoregistration_controller_longest_running_processor_microseconds|crd_autoregistration_controller_queue_latency|crd_autoregistration_controller_retries|crd_autoregistration_controller_unfinished_work_seconds|crd_autoregistration_controller_work_duration|crdEstablishing_adds|crdEstablishing_depth|crdEstablishing_longest_running_processor_microseconds|crdEstablishing_queue_latency|crdEstablishing_retries|crdEstablishing_unfinished_work_seconds|crdEstablishing_work_duration|crd_finalizer_adds|crd_finalizer_depth|crd_finalizer_longest_running_processor_microseconds|crd_finalizer_queue_latency|crd_finalizer_retries|crd_finalizer_unfinished_work_seconds|crd_finalizer_work_duration|crd_naming_condition_controller_adds|crd_naming_condition_controller_depth|crd_naming_condition_controller_longest_running_processor_microseconds|crd_naming_condition_controller_queue_latency|crd_naming_condition_controller_retries|crd_naming_condition_controller_unfinished_work_seconds|crd_naming_condition_controller_work_duration|crd_openapi_controller_adds|crd_openapi_controller_depth|crd_openapi_controller_longest_running_processor_microseconds|crd_openapi_controller_queue_latency|crd_openapi_controller_retries|crd_openapi_controller_unfinished_work_seconds|crd_openapi_controller_work_duration|DiscoveryController_adds|DiscoveryController_depth|DiscoveryController_longest_running_processor_microseconds|DiscoveryController_queue_latency|DiscoveryController_retries|DiscoveryController_unfinished_work_seconds|DiscoveryController_work_duration|kubeproxy_sync_proxy_rules_latency_microseconds|non_structural_schema_condition_controller_adds|non_structural_schema_condition_controller_depth|non_structural_schema_condition_controller_longest_running_processor_microseconds|non_structural_schema_condition_controller_queue_latency|non_structural_schema_condition_controller_retries|non_structural_schema_condition_controller_unfinished_work_seconds|non_structural_schema_condition_controller_work_duration|rest_client_request_latency_seconds|storage_operation_errors_total|storage_operation_status_count)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: etcd_(debugging|disk|server).*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_admission_controller_admission_latencies_seconds_.*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_admission_step_admission_latencies_seconds_.*
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)
+          sourceLabels:
+            - __name__
+            - le
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        serverName: kubernetes
+  jobLabel: component
+  namespaceSelector:
+    matchNames:
+      - default
+  selector:
+    matchLabels:
+      component: apiserver
+      provider: kubernetes

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: coredns
+    app.kubernetes.io/part-of: syn
+  name: coredns
+  namespace: syn-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 15s
+      port: metrics
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - openshift-dns
+  selector:
+    matchLabels:
+      k8s-app: kube-dns

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorCoreDNS.yaml
@@ -14,10 +14,10 @@ spec:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 15s
       port: metrics
-  jobLabel: app.kubernetes.io/name
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
   namespaceSelector:
     matchNames:
       - openshift-dns
-  selector:
-    matchLabels:
-      k8s-app: kube-dns
+  selector: {}

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
@@ -50,11 +50,11 @@ spec:
           regex: etcd_(debugging|disk|request|server).*
           sourceLabels:
             - __name__
-      port: https-metrics
+      port: https
       scheme: https
       tlsConfig:
         insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: prometheus
   namespaceSelector:
     matchNames:
       - openshift-kube-controller-manager

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeControllerManager.yaml
@@ -1,0 +1,63 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kube-controller-manager
+    app.kubernetes.io/part-of: syn
+  name: kube-controller-manager
+  namespace: syn-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: kubelet_docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|object_counts|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: transformation_(transformation_latencies_microseconds|failures_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (admission_quota_controller_adds|admission_quota_controller_depth|admission_quota_controller_longest_running_processor_microseconds|admission_quota_controller_queue_latency|admission_quota_controller_unfinished_work_seconds|admission_quota_controller_work_duration|APIServiceOpenAPIAggregationControllerQueue1_adds|APIServiceOpenAPIAggregationControllerQueue1_depth|APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds|APIServiceOpenAPIAggregationControllerQueue1_queue_latency|APIServiceOpenAPIAggregationControllerQueue1_retries|APIServiceOpenAPIAggregationControllerQueue1_unfinished_work_seconds|APIServiceOpenAPIAggregationControllerQueue1_work_duration|APIServiceRegistrationController_adds|APIServiceRegistrationController_depth|APIServiceRegistrationController_longest_running_processor_microseconds|APIServiceRegistrationController_queue_latency|APIServiceRegistrationController_retries|APIServiceRegistrationController_unfinished_work_seconds|APIServiceRegistrationController_work_duration|autoregister_adds|autoregister_depth|autoregister_longest_running_processor_microseconds|autoregister_queue_latency|autoregister_retries|autoregister_unfinished_work_seconds|autoregister_work_duration|AvailableConditionController_adds|AvailableConditionController_depth|AvailableConditionController_longest_running_processor_microseconds|AvailableConditionController_queue_latency|AvailableConditionController_retries|AvailableConditionController_unfinished_work_seconds|AvailableConditionController_work_duration|crd_autoregistration_controller_adds|crd_autoregistration_controller_depth|crd_autoregistration_controller_longest_running_processor_microseconds|crd_autoregistration_controller_queue_latency|crd_autoregistration_controller_retries|crd_autoregistration_controller_unfinished_work_seconds|crd_autoregistration_controller_work_duration|crdEstablishing_adds|crdEstablishing_depth|crdEstablishing_longest_running_processor_microseconds|crdEstablishing_queue_latency|crdEstablishing_retries|crdEstablishing_unfinished_work_seconds|crdEstablishing_work_duration|crd_finalizer_adds|crd_finalizer_depth|crd_finalizer_longest_running_processor_microseconds|crd_finalizer_queue_latency|crd_finalizer_retries|crd_finalizer_unfinished_work_seconds|crd_finalizer_work_duration|crd_naming_condition_controller_adds|crd_naming_condition_controller_depth|crd_naming_condition_controller_longest_running_processor_microseconds|crd_naming_condition_controller_queue_latency|crd_naming_condition_controller_retries|crd_naming_condition_controller_unfinished_work_seconds|crd_naming_condition_controller_work_duration|crd_openapi_controller_adds|crd_openapi_controller_depth|crd_openapi_controller_longest_running_processor_microseconds|crd_openapi_controller_queue_latency|crd_openapi_controller_retries|crd_openapi_controller_unfinished_work_seconds|crd_openapi_controller_work_duration|DiscoveryController_adds|DiscoveryController_depth|DiscoveryController_longest_running_processor_microseconds|DiscoveryController_queue_latency|DiscoveryController_retries|DiscoveryController_unfinished_work_seconds|DiscoveryController_work_duration|kubeproxy_sync_proxy_rules_latency_microseconds|non_structural_schema_condition_controller_adds|non_structural_schema_condition_controller_depth|non_structural_schema_condition_controller_longest_running_processor_microseconds|non_structural_schema_condition_controller_queue_latency|non_structural_schema_condition_controller_retries|non_structural_schema_condition_controller_unfinished_work_seconds|non_structural_schema_condition_controller_work_duration|rest_client_request_latency_seconds|storage_operation_errors_total|storage_operation_status_count)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: etcd_(debugging|disk|request|server).*
+          sourceLabels:
+            - __name__
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - openshift-kube-controller-manager
+  selector:
+    matchLabels:
+      prometheus: kube-controller-manager

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kube-scheduler
+    app.kubernetes.io/part-of: syn
+  name: kube-scheduler
+  namespace: syn-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: https-metrics
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - openshift-kube-scheduler
+  selector:
+    matchLabels:
+      prometheus: kube-scheduler

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubeScheduler.yaml
@@ -13,11 +13,11 @@ spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 30s
-      port: https-metrics
+      port: https
       scheme: https
       tlsConfig:
         insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: prometheus
   namespaceSelector:
     matchNames:
       - openshift-kube-scheduler

--- a/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubelet.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/70_monitoring_kubernetesControlPlane_serviceMonitorKubelet.yaml
@@ -1,0 +1,105 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/name: kubelet
+    app.kubernetes.io/part-of: syn
+  name: kubelet
+  namespace: syn-monitoring
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: kubelet_(pod_worker_latency_microseconds|pod_start_latency_microseconds|cgroup_manager_latency_microseconds|pod_worker_start_latency_microseconds|pleg_relist_latency_microseconds|pleg_relist_interval_microseconds|runtime_operations|runtime_operations_latency_microseconds|runtime_operations_errors|eviction_stats_age_microseconds|device_plugin_registration_count|device_plugin_alloc_latency_microseconds|network_plugin_operations_latency_microseconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: kubelet_docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|object_counts|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: transformation_(transformation_latencies_microseconds|failures_total)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (admission_quota_controller_adds|admission_quota_controller_depth|admission_quota_controller_longest_running_processor_microseconds|admission_quota_controller_queue_latency|admission_quota_controller_unfinished_work_seconds|admission_quota_controller_work_duration|APIServiceOpenAPIAggregationControllerQueue1_adds|APIServiceOpenAPIAggregationControllerQueue1_depth|APIServiceOpenAPIAggregationControllerQueue1_longest_running_processor_microseconds|APIServiceOpenAPIAggregationControllerQueue1_queue_latency|APIServiceOpenAPIAggregationControllerQueue1_retries|APIServiceOpenAPIAggregationControllerQueue1_unfinished_work_seconds|APIServiceOpenAPIAggregationControllerQueue1_work_duration|APIServiceRegistrationController_adds|APIServiceRegistrationController_depth|APIServiceRegistrationController_longest_running_processor_microseconds|APIServiceRegistrationController_queue_latency|APIServiceRegistrationController_retries|APIServiceRegistrationController_unfinished_work_seconds|APIServiceRegistrationController_work_duration|autoregister_adds|autoregister_depth|autoregister_longest_running_processor_microseconds|autoregister_queue_latency|autoregister_retries|autoregister_unfinished_work_seconds|autoregister_work_duration|AvailableConditionController_adds|AvailableConditionController_depth|AvailableConditionController_longest_running_processor_microseconds|AvailableConditionController_queue_latency|AvailableConditionController_retries|AvailableConditionController_unfinished_work_seconds|AvailableConditionController_work_duration|crd_autoregistration_controller_adds|crd_autoregistration_controller_depth|crd_autoregistration_controller_longest_running_processor_microseconds|crd_autoregistration_controller_queue_latency|crd_autoregistration_controller_retries|crd_autoregistration_controller_unfinished_work_seconds|crd_autoregistration_controller_work_duration|crdEstablishing_adds|crdEstablishing_depth|crdEstablishing_longest_running_processor_microseconds|crdEstablishing_queue_latency|crdEstablishing_retries|crdEstablishing_unfinished_work_seconds|crdEstablishing_work_duration|crd_finalizer_adds|crd_finalizer_depth|crd_finalizer_longest_running_processor_microseconds|crd_finalizer_queue_latency|crd_finalizer_retries|crd_finalizer_unfinished_work_seconds|crd_finalizer_work_duration|crd_naming_condition_controller_adds|crd_naming_condition_controller_depth|crd_naming_condition_controller_longest_running_processor_microseconds|crd_naming_condition_controller_queue_latency|crd_naming_condition_controller_retries|crd_naming_condition_controller_unfinished_work_seconds|crd_naming_condition_controller_work_duration|crd_openapi_controller_adds|crd_openapi_controller_depth|crd_openapi_controller_longest_running_processor_microseconds|crd_openapi_controller_queue_latency|crd_openapi_controller_retries|crd_openapi_controller_unfinished_work_seconds|crd_openapi_controller_work_duration|DiscoveryController_adds|DiscoveryController_depth|DiscoveryController_longest_running_processor_microseconds|DiscoveryController_queue_latency|DiscoveryController_retries|DiscoveryController_unfinished_work_seconds|DiscoveryController_work_duration|kubeproxy_sync_proxy_rules_latency_microseconds|non_structural_schema_condition_controller_adds|non_structural_schema_condition_controller_depth|non_structural_schema_condition_controller_longest_running_processor_microseconds|non_structural_schema_condition_controller_queue_latency|non_structural_schema_condition_controller_retries|non_structural_schema_condition_controller_unfinished_work_seconds|non_structural_schema_condition_controller_work_duration|rest_client_request_latency_seconds|storage_operation_errors_total|storage_operation_status_count)
+          sourceLabels:
+            - __name__
+      port: https-metrics
+      relabelings:
+        - sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      honorTimestamps: false
+      interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: container_(network_tcp_usage_total|network_udp_usage_total|tasks_state|cpu_load_average_10s)
+          sourceLabels:
+            - __name__
+        - action: drop
+          regex: (container_spec_.*|container_file_descriptors|container_sockets|container_threads_max|container_threads|container_start_time_seconds|container_last_seen);;
+          sourceLabels:
+            - __name__
+            - pod
+            - namespace
+        - action: drop
+          regex: (container_blkio_device_usage_total);.+
+          sourceLabels:
+            - __name__
+            - container
+      path: /metrics/cadvisor
+      port: https-metrics
+      relabelings:
+        - sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honorLabels: true
+      interval: 30s
+      path: /metrics/probes
+      port: https-metrics
+      relabelings:
+        - sourceLabels:
+            - __metrics_path__
+          targetLabel: metrics_path
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
+  jobLabel: app.kubernetes.io/name
+  namespaceSelector:
+    matchNames:
+      - kube-system
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubelet


### PR DESCRIPTION
### Components checked

- [x] api-server \
   example: `sum without(instance) (apiserver_admission_controller_admission_duration_seconds_count{job="apiserver"})`
- [x] cAdvisor \
   example: `container_processes{container!="",container!="POD"}`
- [x] controller-manager
   example: `job_controller_job_sync_total`
- [x] coredns
    example: `coredns_cache_entries`
- [x] kube-proxy
   ⛔️ Also [not available](https://prometheus-k8s-openshift-monitoring.apps.lpg1.ocp4-poc.appuio-beta.ch/graph?g0.expr=%7B__name__%3D~%22kubeproxy_.*%22%7D&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h) in the OCP monitoring stack.
- [x] kubelet
   example: `sum by(node) (kubelet_running_pods)`
- [x] scheduler
   example: `sum by(queue) (scheduler_pending_pods)`

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] 🚨 Merge and release https://github.com/projectsyn/component-prometheus/pull/24
<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
