### PR TITLE
Pick-up Metrics in other namespaces

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -32,7 +32,7 @@ parameters:
   components:
     prometheus:
       url: https://github.com/projectsyn/component-prometheus.git
-      version: v1.2.0
+      version: feat/cluster-monitoring
 
   prometheus:
     namespaces:
@@ -56,6 +56,7 @@ parameters:
 
     addons:
       - oauth2-proxy
+      - cluster-monitoring
 
     instances:
       monitoring:

--- a/common.yml
+++ b/common.yml
@@ -32,7 +32,7 @@ parameters:
   components:
     prometheus:
       url: https://github.com/projectsyn/component-prometheus.git
-      version: feat/cluster-monitoring
+      version: v1.3.0
 
   prometheus:
     namespaces:

--- a/common.yml
+++ b/common.yml
@@ -58,6 +58,7 @@ parameters:
       - oauth2-proxy
       - cluster-monitoring
 
+    defaultInstance: monitoring
     instances:
       monitoring:
         common:

--- a/tests/golden/defaults/prometheus/prometheus/00_namespace_syn-monitoring.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/00_namespace_syn-monitoring.yaml
@@ -4,5 +4,6 @@ metadata:
   annotations:
     openshift.io/node-selector: ''
   labels:
+    monitoring.syn.tools/monitoring: 'true'
     name: syn-monitoring
   name: syn-monitoring

--- a/tests/golden/defaults/prometheus/prometheus/10_prometheusOperator_deployment.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/10_prometheusOperator_deployment.yaml
@@ -32,7 +32,9 @@ spec:
         - args:
             - --kubelet-service=kube-system/kubelet
             - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.49.0
-            - -namespaces=syn-monitoring
+            - --prometheus-instance-namespaces=syn-monitoring
+            - --thanos-ruler-instance-namespaces=syn-monitoring
+            - --alertmanager-instance-namespaces=syn-monitoring
           image: quay.io/prometheus-operator/prometheus-operator:v0.49.0
           name: syn-prometheus-operator
           ports:

--- a/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_ClusterMonitoringRole.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_ClusterMonitoringRole.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: syn
+    name: syn-cluster-monitoring-monitoring
+  name: syn-cluster-monitoring-monitoring
+  namespace: syn-monitoring
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_ClusterMonitoringRolebinding.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_ClusterMonitoringRolebinding.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    source: https://github.com/projectsyn/component-prometheus
+  labels:
+    app.kubernetes.io/managed-by: commodore
+    app.kubernetes.io/part-of: syn
+    name: syn-cluster-monitoring-monitoring
+  name: syn-cluster-monitoring-monitoring
+  namespace: syn-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-cluster-monitoring-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-monitoring
+    namespace: syn-monitoring

--- a/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_prometheus.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_prometheus.yaml
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: cookieSecret
               name: oauth2-proxy
-      image: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
+      image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
       name: oauth2-proxy
       resources:
         limits:

--- a/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_prometheus.yaml
+++ b/tests/golden/defaults/prometheus/prometheus/20_monitoring_prometheus_prometheus.yaml
@@ -83,19 +83,27 @@ spec:
       app.kubernetes.io/name: prometheus
       app.kubernetes.io/part-of: kube-prometheus
       app.kubernetes.io/version: 2.29.1
-  podMonitorNamespaceSelector: {}
+  podMonitorNamespaceSelector:
+    matchLabels:
+      monitoring.syn.tools/monitoring: 'true'
   podMonitorSelector: {}
-  probeNamespaceSelector: {}
+  probeNamespaceSelector:
+    matchLabels:
+      monitoring.syn.tools/monitoring: 'true'
   probeSelector: {}
   replicas: 2
   resources:
     requests:
       memory: 400Mi
   retention: 3d
-  ruleNamespaceSelector: {}
+  ruleNamespaceSelector:
+    matchLabels:
+      monitoring.syn.tools/monitoring: 'true'
   ruleSelector: {}
   serviceAccountName: prometheus-monitoring
-  serviceMonitorNamespaceSelector: {}
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      monitoring.syn.tools/monitoring: 'true'
   serviceMonitorSelector: {}
   storage:
     volumeClaimTemplate:


### PR DESCRIPTION
Enables the `cluster-monitoring` addon. Any namespace with label `monitoring.syn.tools/monitoring: true` will be scraped.

See PR https://github.com/projectsyn/component-prometheus/pull/27
## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
